### PR TITLE
More robust 'find_any_in' terminal connection

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,8 @@
 releases:
 
+  v0.0.17:
+  - More robust 'find_any_in' in terminal connection
+
   v0.0.16:
   - Handle missing git installation for shared resource downloader.
 

--- a/cloudify_terminal_sdk/terminal_connection.py
+++ b/cloudify_terminal_sdk/terminal_connection.py
@@ -40,9 +40,11 @@ class TextConnection(base_connection.SSHConnection):
         if not promt_check:
             return -1
 
+        cleanedup_buffer = "".join([i if ord(i) < 128 else '?' for i in buff])
+
         # search possible promt
         for code in promt_check:
-            position = buff.find(code)
+            position = cleanedup_buffer.find(code)
             if position != -1:
                 return position
 

--- a/cloudify_terminal_sdk/terminal_connection.py
+++ b/cloudify_terminal_sdk/terminal_connection.py
@@ -40,6 +40,9 @@ class TextConnection(base_connection.SSHConnection):
         if not promt_check:
             return -1
 
+        # clean up incorrect symbols
+        # original buffer will survive, but for search better to replace all
+        # unicode to placeholders
         cleanedup_buffer = "".join([i if ord(i) < 128 else '?' for i in buff])
 
         # search possible promt

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import setuptools
 
 setuptools.setup(
     name='cloudify-utilities-plugins-sdk',
-    version='0.0.16',
+    version='0.0.17',
     author='Cloudify Platform Ltd.',
     author_email='hello@cloudify.co',
     description='Utilities SDK for extending Cloudify',


### PR DESCRIPTION
Fix for:
```
  File "cloudify_terminal_sdk/terminal_connection.py", line 185, in run
    error_examples, critical_examples)
  File "cloudify_terminal_sdk/terminal_connection.py", line 73, in _check_responses
    if self._find_any_in(response, warnings_with_new_line) != -1:
  File "cloudify_terminal_sdk/terminal_connection.py", line 46, in _find_any_in
    position = buff.find(code)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 360: ordinal not in range(128)
```