### PR TITLE
Small-Fix-For-Missing-File-Type

### DIFF
--- a/cloudify_common_sdk/resource_downloader.py
+++ b/cloudify_common_sdk/resource_downloader.py
@@ -66,7 +66,8 @@ def get_shared_resource(source_path):
                 # try and figure-out the type from headers
                 h = requests.head(source_path)
                 content_type = h.headers.get('content-type')
-                file_type = mimetypes.guess_extension(content_type)
+                file_type = \
+                    mimetypes.guess_extension(content_type, False) or ""
             with requests.get(source_path,
                               allow_redirects=True,
                               stream=True) as response:

--- a/cloudify_common_sdk/tests/test_resource_downloader.py
+++ b/cloudify_common_sdk/tests/test_resource_downloader.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+import mock
 import unittest
 
 import cloudify_common_sdk.resource_downloader as resource_downloader
@@ -36,6 +37,13 @@ class TestResourceDownloader(unittest.TestCase):
     def test_file_with_no_type(self):
         result = resource_downloader.get_shared_resource(FILE_WITH_NO_TYPE_URL)
         self.assertTrue(os.path.exists(result))
+
+    def test_file_with_no_type_no_ext(self):
+        guess_extension_mock = mock.Mock(return_value=None)
+        with mock.patch("mimetypes.guess_extension", guess_extension_mock):
+            result = \
+                resource_downloader.get_shared_resource(FILE_WITH_NO_TYPE_URL)
+            self.assertTrue(os.path.exists(result))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Handle empty result or exception , while trying to guess the file extension , if not provided