### PR TITLE
CY-2754 Obfuscate auth.password in cfy events

### DIFF
--- a/cloudify_common_sdk/filters.py
+++ b/cloudify_common_sdk/filters.py
@@ -14,6 +14,7 @@
 from jinja2 import Environment
 import xmltodict
 from six import string_types, ensure_text
+import copy
 
 
 def get_field_value_recursive(logger, properties, path):
@@ -180,6 +181,14 @@ def shorted_text(obj, size=1024):
     elif len(text) > size:
         return __correct_substr(text, size-3) + "..."
     return text
+
+
+def obfuscate_auth_password(call):
+    if 'auth' in call and 'password' in call['auth']:
+        call_cpy = copy.deepcopy(call)
+        call_cpy['auth']['password'] = 'x' * 16
+        return call_cpy
+    return call
 
 
 def _toxml(value):

--- a/cloudify_common_sdk/tests/test_filters.py
+++ b/cloudify_common_sdk/tests/test_filters.py
@@ -361,6 +361,42 @@ class TestFilters(unittest.TestCase):
             filters.render_template('{{a|toxml}}', {'a': {'b': 'c'}}),
             '<b>c</b>')
 
+    def test_obfuscate_auth_password(self):
+        call = {
+            'host': 'localhost',
+            'auth': {
+                'user': 'someone',
+                'password': 'check'
+            },
+            'port': -1,
+            'response_translation': {
+                "object": ["object_id"]
+            }
+        }
+        obfuscated_call = {
+            'host': 'localhost',
+            'auth': {
+                'user': 'someone',
+                'password': 'xxxxxxxxxxxxxxxx'
+            },
+            'port': -1,
+            'response_translation': {
+                "object": ["object_id"]
+            }
+        }
+        self.assertEqual(filters.obfuscate_auth_password(call),
+                         obfuscated_call)
+
+    def test_obfuscate_auth_password_dont_copy(self):
+        call = {
+            'host': 'localhost',
+            'port': -2,
+            'response_translation': {
+                "object": ["object_id"]
+            }
+        }
+        self.assertIs(filters.obfuscate_auth_password(call), call)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/cloudify_rest_sdk/utility.py
+++ b/cloudify_rest_sdk/utility.py
@@ -27,7 +27,8 @@ from cloudify_rest_sdk import LOGGER_NAME
 from cloudify_common_sdk.filters import (
     translate_and_save,
     shorted_text,
-    render_template
+    render_template,
+    obfuscate_auth_password,
 )
 from cloudify_common_sdk.exceptions import (
     RecoverableStatusCodeCodeException,
@@ -58,7 +59,8 @@ def process(params, template, request_props, prerender=False,
 
     for call in template_yaml['rest_calls']:
         call_with_request_props = request_props.copy()
-        logger.debug('Call: {}'.format(shorted_text(call)))
+        logger.debug(
+            'Call: {}'.format(shorted_text(obfuscate_auth_password(call))))
         # enrich params with items stored in runtime props by prev calls
         params.update(result_properties)
         if not prerender:
@@ -69,7 +71,8 @@ def process(params, template, request_props, prerender=False,
             rendered_call = render_template(call, params)
             call = ast.literal_eval(rendered_call)
         calls.append(call)
-        logger.debug('Rendered call: {}'.format(shorted_text(call)))
+        logger.debug('Rendered call: {}'.format(
+            shorted_text(obfuscate_auth_password(call))))
         call_with_request_props.update(call)
 
         # client/server side certification check
@@ -104,7 +107,8 @@ def process(params, template, request_props, prerender=False,
 
 
 def _send_request(call, resource_callback=None):
-    logger.debug('Request props: {}'.format(shorted_text(call)))
+    logger.debug('Request props: {}'.format(
+        shorted_text(obfuscate_auth_password(call))))
     port = call['port']
     ssl = call['ssl']
     if port == -1:
@@ -225,7 +229,8 @@ def _send_request(call, resource_callback=None):
 
 def _process_response(response, call, store_props):
     logger.debug('Process Response: {}'.format(shorted_text(response)))
-    logger.debug('Call: {}'.format(shorted_text(call)))
+    logger.debug(
+        'Call: {}'.format(shorted_text(obfuscate_auth_password(call))))
     logger.debug('Store props: {}'.format(shorted_text(store_props)))
     logger.debug('Store headers: {}'.format(shorted_text(response.headers)))
     translation_version = call.get('translation_format', 'auto')

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import setuptools
 
 setuptools.setup(
     name='cloudify-utilities-plugins-sdk',
-    version='0.0.21',
+    version='0.0.22',
     author='Cloudify Platform Ltd.',
     author_email='hello@cloudify.co',
     description='Utilities SDK for extending Cloudify',


### PR DESCRIPTION
There used to be plaintext passwords stored in Cloudify logs (events/logs
tables).  This patch replaces real passwords with sixteen letters 'x'.