### PR TITLE
Added buildins python version dependend string to _compat file

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,8 @@
 releases:
 
+  v0.0.27:
+  - Added python version dependent builtins_open string used in libvirt plugin
+
   v0.0.20:
   - Apply futurize fixes for python3
 

--- a/cloudify_common_sdk/_compat.py
+++ b/cloudify_common_sdk/_compat.py
@@ -22,11 +22,13 @@ PY2 = sys.version_info[0] == 2
 
 if PY2:
     text_type = unicode
+    builtins_open = '__builtin__.open'
 
 else:
     text_type = str
+    builtins_open = 'builtins.open'
 
 
 __all__ = [
-    'PY2', 'text_type',
+    'PY2', 'text_type', 'builtins_open'
 ]

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import setuptools
 
 setuptools.setup(
     name='cloudify-utilities-plugins-sdk',
-    version='0.0.26',
+    version='0.0.27',
     author='Cloudify Platform Ltd.',
     author_email='hello@cloudify.co',
     description='Utilities SDK for extending Cloudify',


### PR DESCRIPTION
Quick change - added builtins_open string which is used in libvirt plugin.