### PR TITLE
cloudify_rest_sdk SSL cert fix for - TypeError: a bytes-like object is required, not str

### DIFF
--- a/cloudify_rest_sdk/tests/test_sdk.py
+++ b/cloudify_rest_sdk/tests/test_sdk.py
@@ -864,8 +864,15 @@ class TestSdk(unittest.TestCase):
                 "cloudify_rest_sdk.utility.tempfile.mkstemp",
                 mock.Mock(return_value=['fake_fd', '/tmp/fake_tmp'])
             ):
+                def _verify_cert_data_type(_, data):
+                    assert isinstance(data, bytes), \
+                        "Attempt of writing to temp file certificate data " \
+                        "which has invalid type: " \
+                        f"`{type(data).__name__}`, expected: `bytes`"
+
                 fake_os = mock.Mock()
                 fake_os.path.isfile = mock.Mock(return_value=False)
+                fake_os.write = mock.Mock(side_effect=_verify_cert_data_type)
                 fake_os.remove = mock.Mock(
                     side_effect=Exception("can't remove"))
                 with mock.patch("cloudify_rest_sdk.utility.os", fake_os):

--- a/cloudify_rest_sdk/utility.py
+++ b/cloudify_rest_sdk/utility.py
@@ -82,7 +82,7 @@ def process(params, template, request_props, prerender=False,
             if isinstance(call_with_request_props.get(field), string_types):
                 if not os.path.isfile(call_with_request_props.get(field)):
                     fd, destination = tempfile.mkstemp()
-                    os.write(fd, call_with_request_props.get(field))
+                    os.write(fd, call_with_request_props.get(field).encode())
                     os.close(fd)
                     # replace to path to content
                     call_with_request_props[field] = destination


### PR DESCRIPTION
This is `cloudify_rest_sdk` bugfix for issue which occurs working with SSL certificates.
When verification is enabled and certificate is passed as a string - an exception is being raised:

```
TypeError: a bytes-like object is required, not str
```

this is caused by the fact that `os.write` method expects `bytes` object as second argument (not `str`).

In case of approval and merge I would like also to ask about releasing a new version of `cloudify-utilities-plugin` which will consme this change.
