### PR TITLE
CYBL-1593-Handle-Obfuscation-End-Of-DictVal

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,5 @@
 releases:
+  v0.0.67: Add special handling to obsufication regex to preserve double-quotes.
   v0.0.66: Add update_dict_values in utils.py
   v0.0.65: Add more intrinsic functions support.
   v0.0.64: Include new lines in obfuscated values.

--- a/cloudify_common_sdk/filters.py
+++ b/cloudify_common_sdk/filters.py
@@ -20,7 +20,7 @@ import re
 from ._compat import text_type
 
 OBFUSCATION_KEYWORDS = ('PASSWORD', 'SECRET', 'TOKEN',)
-OBFUSCATION_RE = re.compile(r'((password|secret|token)(:|=)\s*)(\S+)',
+OBFUSCATION_RE = re.compile(r'((password|secret|token)(:|=)\s*)(?:[^\\"])*',
                             flags=re.IGNORECASE | re.MULTILINE)
 OBFUSCATED_SECRET = 'x' * 16
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import setuptools
 
 setuptools.setup(
     name='cloudify-utilities-plugins-sdk',
-    version='0.0.66',
+    version='0.0.67',
     author='Cloudify Platform Ltd.',
     author_email='hello@cloudify.co',
     description='Utilities SDK for extending Cloudify',


### PR DESCRIPTION
we have a case where the obfuscation might happen at the end of line string 
```
{
"some_value":"token: asassaassa\n",
}
```
what happens when the code apply the regex it will replace everything after the `token: ` , which would lead to invalid JSON structure 
```
{
"some_value":"token: xxxxxxxxxx
}
```