### PR TITLE
CYBL-1593-Handle-Dict-Obfuscation-Val

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,5 @@
 releases:
+  v0.0.69: handle dict obfuscation value.
   v0.0.68: Add more generic handling to obfuscation.
   v0.0.67: Add special handling to obfuscation regex to preserve double-quotes.
   v0.0.66: Add update_dict_values in utils.py

--- a/cloudify_common_sdk/filters.py
+++ b/cloudify_common_sdk/filters.py
@@ -201,6 +201,23 @@ def obfuscate_passwords(obj):
     any passwords, original is returned and deepcopy never performed.
     """
     def obfuscate_value(matchobj):
+        last_portion = matchobj.group(0).split()[-1].lower()
+        re_numbers = re.compile(r'\d+')
+        true_false = re.compile(r'[[+](true|false)')
+        if re_numbers.search(last_portion) or true_false.search(last_portion):
+            return matchobj.group(1) + last_portion
+        if matchobj.group(0).endswith('{'):
+            return matchobj.group(1) + '{'
+        if matchobj.group(0).endswith('['):
+            return matchobj.group(1) + '['
+        if matchobj.group(0).endswith('('):
+            return matchobj.group(1) + '('
+        if matchobj.group(0).lower().endswith('true'):
+            return matchobj.group(1) + 'true'
+        if matchobj.group(0).lower().endswith('false'):
+            return matchobj.group(1) + 'false'
+        if matchobj.group(0).lower().endswith('null'):
+            return matchobj.group(1) + 'null'
         if not matchobj.group(1).endswith('""'):
             return matchobj.group(1) + OBFUSCATED_SECRET
         else:

--- a/cloudify_common_sdk/tests/test_filters.py
+++ b/cloudify_common_sdk/tests/test_filters.py
@@ -435,6 +435,56 @@ class TestFilters(unittest.TestCase):
         self.assertIn(u'Hello world!',
                       u'{0}'.format(filters.obfuscate_passwords(call)))
 
+    def test_obfuscate_json_string(self):
+        call = """{
+    "Token": "HIDE ME",
+    "number": -2,
+    "SECRET": "HIDE ME",
+    "Authentication Header": {
+        "Bearer Token": "HIDE ME",
+        "Bearer-Token": "HIDE ME TOO",
+    },
+    "message": "Hello world!",
+    "src_registry_password": {
+        "value": "some_value"
+    },
+    "array_password": ["first_val", "second_val"],
+    "true_false_token": true,
+    "null_password": null,
+    "set_token": ("firstToken","secondToken","thirdToken"),
+    "number_secret": 123.456,
+    "weird_password": "foo:",
+    "array2_password": [123.123],
+    "array3_password": [false],
+    "array4_password": [true, false],
+    "dict2_password": {"x":true},
+}"""
+        obfuscated_call = """{
+    "Token": "xxxxxxxxxxxxxxxx",
+    "number": -2,
+    "SECRET": "xxxxxxxxxxxxxxxx",
+    "Authentication Header": {
+        "Bearer Token": "xxxxxxxxxxxxxxxx",
+        "Bearer-Token": "xxxxxxxxxxxxxxxx",
+    },
+    "message": "Hello world!",
+    "src_registry_password": {
+        "value": "some_value"
+    },
+    "array_password": ["first_val", "second_val"],
+    "true_false_token": true,
+    "null_password": null,
+    "set_token": ("firstToken","secondToken","thirdToken"),
+    "number_secret": 123.456,
+    "weird_password": "xxxxxxxxxxxxxxxx",
+    "array2_password": [123.123],
+    "array3_password": [false],
+    "array4_password": [true, false],
+    "dict2_password": {"x":true},
+}"""
+        self.assertEqual(filters.obfuscate_passwords(call),
+                         obfuscated_call)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import setuptools
 
 setuptools.setup(
     name='cloudify-utilities-plugins-sdk',
-    version='0.0.68',
+    version='0.0.69',
     author='Cloudify Platform Ltd.',
     author_email='hello@cloudify.co',
     description='Utilities SDK for extending Cloudify',


### PR DESCRIPTION
this is another case , that was missed by the special handling , where the value to obfuscate is a dict inside the string 
```
"some_password": {
	"value": ""
},
```
where the regex will detect this as value to hide , then result in this output 
```
"some_password": xxxxxxxxxxxxxxxx "value": ""
},
```
now we are checking if the found regex contain `{` at the end , then just skip