### PR TITLE
RD-5012-Handle-Logging-Errors

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 releases:
-  v0.0.72: handle empty set and dict values obfuscation.
+  v0.0.73: handle empty set and dict values obfuscation.
+  v0.0.72: Handle logging errors with weird characters being emitted by processes stdout/stderr.
   v0.0.71: Only update values if new value provided in dict update.
   v0.0.70: handle array of numbers and number regex.
   v0.0.69: handle dict obfuscation value.

--- a/cloudify_common_sdk/processes.py
+++ b/cloudify_common_sdk/processes.py
@@ -77,7 +77,7 @@ class GeneralExecutor(object):
     def _emit_log_message(self, message, prefix=None, logger=None):
         logger = logger or self.logger.info
         if hasattr(message, 'decode'):
-            message = message.decode('utf-8', 'replace')
+            message = message.decode('ascii', 'ignore')
         clean_message = obfuscate_passwords(message)
 
         try:
@@ -97,10 +97,10 @@ class GeneralExecutor(object):
         try:
             stdout, stderr = self.process.communicate()
             if stdout:
-                for line in stdout.decode('utf-8').splitlines():
+                for line in stdout.decode('ascii', 'ignore').splitlines():
                     self._stdout.append(self._emit_log_message(line))
             if stderr:
-                for line in stderr.decode('utf-8').splitlines():
+                for line in stderr.decode('ascii', 'ignore').splitlines():
                     self._stderr.append(
                         self._emit_log_message(
                             line, prefix='<err>', logger=self.logger.error))
@@ -239,7 +239,8 @@ def general_executor(script_path, ctx, process):
         ctx.logger.debug("Context proxy closed")
 
     execution.check_exception()
-    return execution.stdout
+    # some processes returns only stderr
+    return execution.stdout if execution.stdout else execution.stderr
 
 
 def process_execution(script_func, script_path, ctx=None, process=None):

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import setuptools
 
 setuptools.setup(
     name='cloudify-utilities-plugins-sdk',
-    version='0.0.72',
+    version='0.0.73',
     author='Cloudify Platform Ltd.',
     author_email='hello@cloudify.co',
     description='Utilities SDK for extending Cloudify',


### PR DESCRIPTION
some processes emit some characters that is not supported when decoding using utf-8 
some characters indicating progress would have the following format `\x1b[96;1m\u2826\x1b` , 
using `decode('ascii','ignore')` we would be able to handle this logging issue