### PR TITLE
Support git ssh notation for tf

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,5 @@
 releases:
+  v0.0.76: support git ssh notation in get_shared_resource
   v0.0.75: fix obfuscate pattern to handle new lines inside string.
   v0.0.74: handle dynamic shell variables obfuscation.
   v0.0.73: handle empty set and dict values obfuscation.

--- a/cloudify_common_sdk/resource_downloader.py
+++ b/cloudify_common_sdk/resource_downloader.py
@@ -60,7 +60,18 @@ def get_shared_resource(source_path, dir=None, username=None, password=None):
     tmp_path = source_path
     split = source_path.split('://')
     schema = split[0]
-    if schema in ['http', 'https']:
+    if "git@" in source_path:
+        try:
+            from git import Repo
+            tmp_path = tempfile.mkdtemp(dir=dir)
+            Repo.clone_from(source_path,
+                            tmp_path)
+        except ImportError:
+            raise NonRecoverableError(
+                "Clone git repo is only supported if git is installed "
+                "on your manager and accessible in the management "
+                "user's path.")
+    elif schema in ['http', 'https']:
         bare_url, *query_string = source_path.split('?')
         file_name = bare_url.rsplit('/', 1)[1]
         # user might provide a link to file with no extension

--- a/cloudify_common_sdk/resource_downloader.py
+++ b/cloudify_common_sdk/resource_downloader.py
@@ -1,4 +1,5 @@
 import os
+import git
 import zipfile
 import requests
 import tempfile
@@ -62,10 +63,15 @@ def get_shared_resource(source_path, dir=None, username=None, password=None):
     schema = split[0]
     if "git@" in source_path:
         try:
-            from git import Repo
             tmp_path = tempfile.mkdtemp(dir=dir)
-            Repo.clone_from(source_path,
+            git.Repo.clone_from(source_path,
                             tmp_path)
+        except git.exc.GitCommandError as e:
+            if "Permission denied" in str(e):
+                raise NonRecoverableError(
+                    "User cfyuser might not have read permissions to "
+                    "the private key or the key is not allowed to the repo"
+                )
         except ImportError:
             raise NonRecoverableError(
                 "Clone git repo is only supported if git is installed "
@@ -103,14 +109,13 @@ def get_shared_resource(source_path, dir=None, username=None, password=None):
                         source_temp.write(chunk)
         else:
             try:
-                from git import Repo
                 tmp_path = tempfile.mkdtemp(dir=dir)
                 auth_url_part = ''
                 if username:
                     auth_url_part = '{}:{}@'.format(username, password)
                 updated_url = '{}://{}{}'.format(
                     schema, auth_url_part, split[1])
-                Repo.clone_from(updated_url,
+                git.Repo.clone_from(updated_url,
                                 tmp_path)
             except ImportError:
                 raise NonRecoverableError(

--- a/cloudify_common_sdk/resource_downloader.py
+++ b/cloudify_common_sdk/resource_downloader.py
@@ -64,8 +64,7 @@ def get_shared_resource(source_path, dir=None, username=None, password=None):
     if "git@" in source_path:
         try:
             tmp_path = tempfile.mkdtemp(dir=dir)
-            git.Repo.clone_from(source_path,
-                            tmp_path)
+            git.Repo.clone_from(source_path, tmp_path)
         except git.exc.GitCommandError as e:
             if "Permission denied" in str(e):
                 raise NonRecoverableError(
@@ -115,8 +114,7 @@ def get_shared_resource(source_path, dir=None, username=None, password=None):
                     auth_url_part = '{}:{}@'.format(username, password)
                 updated_url = '{}://{}{}'.format(
                     schema, auth_url_part, split[1])
-                git.Repo.clone_from(updated_url,
-                                tmp_path)
+                git.Repo.clone_from(updated_url, tmp_path)
             except ImportError:
                 raise NonRecoverableError(
                     "Clone git repo is only supported if git is installed "

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import setuptools
 
 setuptools.setup(
     name='cloudify-utilities-plugins-sdk',
-    version='0.0.75',
+    version='0.0.76',
     author='Cloudify Platform Ltd.',
     author_email='hello@cloudify.co',
     description='Utilities SDK for extending Cloudify',


### PR DESCRIPTION
So far only sources starting with https:// are supported. This PR is adding possibility to provide git@repo. 

Assumptions:
Public key is allowed to the repo and the cfyuser has the access to the corresponding private key.