### PR TITLE
handle-helm-case

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,5 @@
 releases:
+  v0.0.83: Handle Obfuscation case from helm output.
   v0.0.82: Remove type casting on intrinsic functions other than get_secret.
   v0.0.81: Add complex path support for get_attribute intrinsic resolvers.
   v0.0.80: Make obfuscation only for logs.

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import setuptools
 
 setuptools.setup(
     name='cloudify-utilities-plugins-sdk',
-    version='0.0.82',
+    version='0.0.83',
     author='Cloudify Platform Ltd.',
     author_email='hello@cloudify.co',
     description='Utilities SDK for extending Cloudify',


### PR DESCRIPTION
we have a case that was encountered from helm output , where we have an obfuscation key like this 
```
secret:\n
  secretName: whatever
```
and with current handling , the result would go like this 
```
secret:xxxxxxxxxxxx\n
  secretName: whatever
```
which is not quite right 