### PR TITLE
CYBL-1809-Fix-Resource-Downloader

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,5 @@
 releases:
+  v0.0.85: Name the downloaded resources with proper-suffix.
   v0.0.84: Add more keys to obfuscation.
   v0.0.83: Handle Obfuscation case from helm output.
   v0.0.82: Remove type casting on intrinsic functions other than get_secret.

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import setuptools
 
 setuptools.setup(
     name='cloudify-utilities-plugins-sdk',
-    version='0.0.84',
+    version='0.0.85',
     author='Cloudify Platform Ltd.',
     author_email='hello@cloudify.co',
     description='Utilities SDK for extending Cloudify',


### PR DESCRIPTION
handle suffix better for downloader resource , in case of `.tf.json` files from terraform , the file name will end up with something like this `tmpxxxxxjson` which is not what we want [ with this change it will preserve the last part `file_name.tf.json` ]