### PR TITLE
Unzip-Cleanup-On-Exception

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,5 @@
 releases:
+  v0.0.87: Handle Some cleanup of temp directories in case of Exception.
   v0.0.86: Return the correct resolved value of properties.
   v0.0.85: Name the downloaded resources with proper-suffix.
   v0.0.84: Add more keys to obfuscation.

--- a/cloudify_common_sdk/resource_downloader.py
+++ b/cloudify_common_sdk/resource_downloader.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import zipfile
 import requests
 import tempfile
@@ -35,6 +36,10 @@ def unzip_archive(archive_path, skip_parent_directory=True):
                     os.chmod(reset_target, info.external_attr >> 16)
         if skip_parent_directory:
             into_dir = _handle_parent_directory(into_dir)
+    except zipfile.BadZipFile as e:
+        # clean up that temp directory and raise the exception
+        shutil.rmtree(into_dir)
+        raise e
     finally:
         if zip_in:
             zip_in.close()
@@ -50,6 +55,10 @@ def untar_archive(archive_path, skip_parent_directory=True):
         tar_in.extractall(into_dir)
         if skip_parent_directory:
             into_dir = _handle_parent_directory(into_dir)
+    except tarfile.TarError as e:
+        # clean up that temp directory and raise the exception
+        shutil.rmtree(into_dir)
+        raise e
     finally:
         if tar_in:
             tar_in.close()

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import setuptools
 
 setuptools.setup(
     name='cloudify-utilities-plugins-sdk',
-    version='0.0.86',
+    version='0.0.87',
     author='Cloudify Platform Ltd.',
     author_email='hello@cloudify.co',
     description='Utilities SDK for extending Cloudify',


### PR DESCRIPTION
handle unzipping clean up on exception , otherwise we will leave behind empty directories on `/tmp`