### PR TITLE
Fix-Get-Environment-Capability

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,5 @@
 releases:
+  v0.0.89: Pass parent id to resolve get_environment_capability intrinsic functions.
   v0.0.88: Add support for complex get_secret.
   v0.0.87: Handle Some cleanup of temp directories in case of Exception.
   v0.0.86: Return the correct resolved value of properties.

--- a/cloudify_common_sdk/utils.py
+++ b/cloudify_common_sdk/utils.py
@@ -454,7 +454,7 @@ def resolve_intrinsic_functions(prop, dep_id=None):
                 path = prop
             capability = get_capability(target_dep_id, capability, path)
             if not isinstance(capability, text_type):
-                capability = resolve_value(capability, dep_id)
+                capability = resolve_value(capability, target_dep_id)
             return capability
         if 'get_label' in prop:
             prop = prop.get('get_label')

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import setuptools
 
 setuptools.setup(
     name='cloudify-utilities-plugins-sdk',
-    version='0.0.88',
+    version='0.0.89',
     author='Cloudify Platform Ltd.',
     author_email='hello@cloudify.co',
     description='Utilities SDK for extending Cloudify',


### PR DESCRIPTION
in some cases get_environment_capability can be an intrinsic function , so we should pass the parent_id to resolve the function correctly