### PR TITLE
adding-more-secrets-handling

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,5 @@
 releases:
+  v0.0.91: Fix an issue with hidden value secret in case of other user.
   v0.0.90: Pass correct node_instace_dir for git download.
   v0.0.89: Pass parent id to resolve get_environment_capability intrinsic functions.
   v0.0.88: Add support for complex get_secret.

--- a/cloudify_common_sdk/tests/test_utils.py
+++ b/cloudify_common_sdk/tests/test_utils.py
@@ -369,7 +369,7 @@ class BatchUtilsTests(unittest.TestCase):
     @mock.patch('cloudify_common_sdk.utils.get_rest_client')
     def test_get_secret(self, mock_client):
         prop = 'bar'
-        utils.get_secret(secret_name=prop)
+        utils.get_secret(secret_name=prop, path=None)
         assert mock.call().secrets.get('bar') in mock_client.mock_calls
 
     @mock.patch('cloudify_common_sdk.utils.get_rest_client')

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import setuptools
 
 setuptools.setup(
     name='cloudify-utilities-plugins-sdk',
-    version='0.0.90',
+    version='0.0.91',
     author='Cloudify Platform Ltd.',
     author_email='hello@cloudify.co',
     description='Utilities SDK for extending Cloudify',


### PR DESCRIPTION
Cloudify behaviour in case you define a secret with hidden value , it would be visible inside the tenant , but other users won't see the value for that , hence since we are using the rest_client that logic applies here , but that is not the case when working with the cloudify node context