### PR TITLE
Enforce submodules init on resource downloader

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,5 @@
 releases:
+  v0.0.99: Enforce submodules init in resource downloader.
   v0.0.98: Support GCP in K8s SDK.
   v0.0.97: Add host to kube sdk decorator.
   v0.0.96: Use setuptools.find_packages in setup.py.

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import setuptools
 
 setuptools.setup(
     name='cloudify-utilities-plugins-sdk',
-    version='0.0.98',
+    version='0.0.99',
     author='Cloudify Platform Ltd.',
     author_email='hello@cloudify.co',
     description='Utilities SDK for extending Cloudify',


### PR DESCRIPTION
 force needed in case there are folders already in the repo otherwise it initiates the submodule but says that all files were deleted