### PR TITLE
Update utility.py - obfuscate response content

### DIFF
--- a/cloudify_rest_sdk/utility.py
+++ b/cloudify_rest_sdk/utility.py
@@ -205,7 +205,7 @@ def _send_request(call, resource_callback=None):
                 raise
 
     logger.info('Response content: \n{}...'
-                .format(shorted_text(response.content)))
+                .format(shorted_text(obfuscate_passwords(repr(response.content)))))
     logger.info('Status code: {}'.format(repr(response.status_code)))
 
     try:


### PR DESCRIPTION
Response content should be obfuscated as it may contain secrets. Example: Response to OAuth2.0 token request, which contains the access token (https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-client-creds-grant-flow#successful-response-1).