### PR TITLE
Update filters.py - obfuscate leaf string values

### DIFF
--- a/cloudify_common_sdk/filters.py
+++ b/cloudify_common_sdk/filters.py
@@ -300,6 +300,10 @@ def obfuscate_passwords(obj, regex_string=OBFUSCATION_RE):
             else:
                 a_copy[k] = OBFUSCATED_SECRET
             result = a_copy
+        elif isinstance(v,(text_type,)):
+            a_copy = deepcopy(result)
+            a_copy[k] = regex_string.sub(obfuscate_value, v)
+            result = a_copy
         if isinstance(v, (dict, list,)):
             obfuscated_v = obfuscate_passwords(v)
             if obfuscated_v is not v:


### PR DESCRIPTION
Parse and obfuscate passwords contained in leaf string values. Although such values are strings, they may contain key-value pairs incl. secrets / passwords, which should be obfuscated.  Example: The request to get OAuth2.0 access token from Azure AD send using a REST template with the client secret in its payload (key: payload, value: URL encoded string composed of client_id=x&client_secret=y ....). Payload structure specification:  https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-client-creds-grant-flow#first-case-access-token-request-with-a-shared-secret